### PR TITLE
Refactor the workflow.

### DIFF
--- a/.github/workflows/cloud-nuke.yaml
+++ b/.github/workflows/cloud-nuke.yaml
@@ -20,6 +20,7 @@ jobs:
     concurrency:
       group: ${{ github.ref }}
       cancel-in-progress: true
+    if: github.event_name == 'push'
 
     steps:
       - name: Check out the repo
@@ -44,7 +45,6 @@ jobs:
   # directory as the workflows. This allows us to configure the build contexts in a centralized location, keeping
   # the workflow code DRY.
   build-matrix:
-    needs: cloud-nuke-dry-run
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2022-01-25
+
+### Added
+
+- [Renovate Bot](https://docs.renovatebot.com) for keeping `cloud-nuke` up to date.
+
+### Changed
+
+- The `cloud-nuke-dry-run` job now only runs on `push` events, while the remaining jobs only run on `schedule` events.
+  - This is done to avoid doing a dry-run before every scheduled job as there is no benefit to doing that.
+
 ## 2022-01-24
 
 ### Changed


### PR DESCRIPTION
### Changed

- The `cloud-nuke-dry-run` job now only runs on `push` events, while the remaining jobs only run on `schedule` events.
  - This is done to avoid doing a dry-run before every scheduled job as there is no benefit to doing that.